### PR TITLE
Specify template members in jetfinder

### DIFF
--- a/EventFiltering/PWGJE/fullJetFilter.cxx
+++ b/EventFiltering/PWGJE/fullJetFilter.cxx
@@ -40,7 +40,7 @@ using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using selectedClusters = o2::soa::Filtered<o2::aod::EMCALClusters>;
-using filteredJets = o2::soa::Filtered<o2::aod::Jets>;
+using filteredJets = o2::soa::Filtered<o2::aod::FullJets>;
 
 struct fullJetFilter {
   enum {

--- a/PWGJE/TableProducer/jetfinder.cxx
+++ b/PWGJE/TableProducer/jetfinder.cxx
@@ -201,11 +201,11 @@ struct JetFinderTask {
                                  constituent.E(), constituent.m(), constituent.user_index());
           }
 
-          if (constituent.user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::track)) {
-            trackconst.push_back(constituent.user_info<FastJetUtilities::fastjet_user_info>().getIndex());
+          if (constituent.template user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::track)) {
+            trackconst.push_back(constituent.template user_info<FastJetUtilities::fastjet_user_info>().getIndex());
           }
-          if (constituent.user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::cluster)) {
-            clusterconst.push_back(constituent.user_info<FastJetUtilities::fastjet_user_info>().getIndex());
+          if (constituent.template user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::cluster)) {
+            clusterconst.push_back(constituent.template user_info<FastJetUtilities::fastjet_user_info>().getIndex());
           }
         }
         constituentsTable(jetsTable.lastIndex(), trackconst, clusterconst, std::vector<int>());

--- a/PWGJE/TableProducer/jetfinderhf.cxx
+++ b/PWGJE/TableProducer/jetfinderhf.cxx
@@ -297,7 +297,7 @@ struct JetFinderHFTask {
       for (const auto& jet : jets) {
         bool isHFJet = false;
         for (const auto& constituent : jet.constituents()) {
-          if (constituent.user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::candidateHF)) {
+          if (constituent.template user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::candidateHF)) {
             isHFJet = true;
             candidatepT = constituent.pt();
             break;
@@ -319,14 +319,14 @@ struct JetFinderHFTask {
                                  constituent.E(), constituent.m(), constituent.user_index());
           }
 
-          if (constituent.user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::track)) {
-            trackconst.push_back(constituent.user_info<FastJetUtilities::fastjet_user_info>().getIndex());
+          if (constituent.template user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::track)) {
+            trackconst.push_back(constituent.template user_info<FastJetUtilities::fastjet_user_info>().getIndex());
           }
-          if (constituent.user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::cluster)) {
-            clusterconst.push_back(constituent.user_info<FastJetUtilities::fastjet_user_info>().getIndex());
+          if (constituent.template user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::cluster)) {
+            clusterconst.push_back(constituent.template user_info<FastJetUtilities::fastjet_user_info>().getIndex());
           }
-          if (constituent.user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::candidateHF)) {
-            candconst.push_back(constituent.user_info<FastJetUtilities::fastjet_user_info>().getIndex());
+          if (constituent.template user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::candidateHF)) {
+            candconst.push_back(constituent.template user_info<FastJetUtilities::fastjet_user_info>().getIndex());
           }
         }
         constituentsTable(jetsTable.lastIndex(), trackconst, clusterconst, candconst);

--- a/PWGJE/Tasks/FullJetTriggerQATask.cxx
+++ b/PWGJE/Tasks/FullJetTriggerQATask.cxx
@@ -354,7 +354,7 @@ struct JetTriggerQA {
   }
 
   void process(soa::Join<aod::Collisions, aod::EvSels, aod::FullJetFilters>::iterator const& collision,
-               soa::Join<aod::Jets, aod::JetConstituents> const& jets,
+               soa::Join<aod::FullJets, aod::FullJetConstituents> const& jets,
                aod::Tracks const& tracks,
                selectedClusters const& clusters)
   {
@@ -416,8 +416,8 @@ struct JetTriggerQA {
 
     double maxClusterObservableEMCAL = -1., maxClusterObservableDCAL = -1.;
     selectedClusters::iterator maxClusterEMCAL, maxClusterDCAL;
-    std::vector<soa::Join<aod::Jets, aod::JetConstituents>::iterator> vecMaxJet;
-    std::vector<soa::Join<aod::Jets, aod::JetConstituents>::iterator> vecMaxJetNoFiducial;
+    std::vector<soa::Join<aod::FullJets, aod::FullJetConstituents>::iterator> vecMaxJet;
+    std::vector<soa::Join<aod::FullJets, aod::FullJetConstituents>::iterator> vecMaxJetNoFiducial;
 
     for (const auto& jet : jets) {
       double jetPt = jet.pt(), jetR = jet.r() * 1e-2;

--- a/PWGJE/Tasks/jetsubstructurehf.cxx
+++ b/PWGJE/Tasks/jetsubstructurehf.cxx
@@ -145,7 +145,7 @@ struct JetSubstructureHFTask {
       }
       bool isHFInSubjet1 = false;
       for (auto& subjet1Constituent : parentSubJet1.constituents()) {
-        if (subjet1Constituent.user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::candidateHF)) {
+        if (subjet1Constituent.template user_info<FastJetUtilities::fastjet_user_info>().getStatus() == static_cast<int>(JetConstituentStatus::candidateHF)) {
           isHFInSubjet1 = true;
           break;
         }


### PR DESCRIPTION
As template member function template needs to be
specified in the call of the user_info function of fastjet::PseudoJet, see
https://stackoverflow.com/questions/3786360/confusing-template-error 

Otherwise builds on macOS with clang will create
a compiler error.